### PR TITLE
Revamp horse registry UI

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,0 +1,361 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
+
+:root {
+  --primary: #5b21b6;
+  --primary-soft: #ede9fe;
+  --primary-strong: #4c1d95;
+  --surface: rgba(255, 255, 255, 0.88);
+  --text: #111827;
+  --muted: #6b7280;
+  --border: rgba(120, 113, 198, 0.15);
+  --shadow: 0 24px 55px rgba(79, 70, 229, 0.16);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at 10% 20%, rgba(252, 231, 243, 0.7), transparent 55%),
+    radial-gradient(circle at 90% 10%, rgba(224, 231, 255, 0.75), transparent 45%),
+    linear-gradient(160deg, #eef2ff 0%, #faf5ff 40%, #fdf4ff 100%);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.app-shell {
+  padding: 40px 20px 80px;
+}
+
+.app-container {
+  max-width: 1180px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.card {
+  background: var(--surface);
+  backdrop-filter: blur(12px);
+  border-radius: 20px;
+  padding: 28px;
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border);
+}
+
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.page-header__text h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.6rem);
+  font-weight: 700;
+  color: var(--primary-strong);
+}
+
+.page-subtitle {
+  margin: 8px 0 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.search-form {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  width: 100%;
+}
+
+.search-form input {
+  flex: 1;
+}
+
+.search-form--compact {
+  margin-top: 12px;
+}
+
+input,
+select,
+button {
+  font: inherit;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  padding: 12px 16px;
+  transition: all 0.2s ease;
+  background: white;
+  color: inherit;
+}
+
+input:focus,
+select:focus {
+  outline: none;
+  border-color: rgba(94, 66, 228, 0.5);
+  box-shadow: 0 0 0 4px rgba(129, 140, 248, 0.25);
+}
+
+button {
+  cursor: pointer;
+  font-weight: 600;
+  border: none;
+  background: var(--primary-soft);
+  color: var(--primary-strong);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, #7c3aed, #5b21b6);
+  color: white;
+  border: none;
+  box-shadow: 0 12px 25px rgba(99, 102, 241, 0.25);
+}
+
+.primary-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(99, 102, 241, 0.35);
+}
+
+.secondary-button {
+  background: white;
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  color: var(--primary-strong);
+}
+
+.secondary-button:hover {
+  border-color: rgba(79, 70, 229, 0.4);
+}
+
+.ghost-button {
+  background: transparent;
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  color: var(--primary-strong);
+}
+
+.ghost-button:hover:not(:disabled) {
+  border-color: rgba(79, 70, 229, 0.4);
+  background: rgba(79, 70, 229, 0.05);
+}
+
+.collapsible {
+  display: block;
+}
+
+.collapsible summary {
+  font-size: 1.05rem;
+  cursor: pointer;
+  list-style: none;
+  margin-bottom: 12px;
+  position: relative;
+  padding-left: 24px;
+}
+
+.collapsible summary::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 10px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #a855f7, #6366f1);
+  box-shadow: 0 0 0 4px rgba(167, 139, 250, 0.3);
+}
+
+.collapsible summary::-webkit-details-marker {
+  display: none;
+}
+
+.section-subtitle {
+  margin: 0 0 16px;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.form-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: var(--primary-strong);
+}
+
+.table-wrapper {
+  margin-top: 16px;
+  overflow-x: auto;
+  border-radius: 16px;
+  border: 1px solid rgba(226, 232, 240, 0.7);
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+.data-table thead {
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.data-table th,
+.data-table td {
+  padding: 14px 16px;
+  text-align: left;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.8);
+}
+
+.data-table tbody tr:hover {
+  background: rgba(99, 102, 241, 0.06);
+}
+
+.data-table th {
+  font-weight: 600;
+  color: var(--primary-strong);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+}
+
+.data-table td:last-child {
+  text-align: right;
+}
+
+.empty-state {
+  text-align: center;
+  color: var(--muted);
+  padding: 18px 0;
+}
+
+.pagination {
+  margin-top: 20px;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  color: var(--muted);
+}
+
+.inline-form {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+}
+
+.inline-form input,
+.inline-form select {
+  min-width: 200px;
+}
+
+.split-layout {
+  margin-top: 24px;
+  display: grid;
+  gap: 20px;
+}
+
+.panel {
+  background: rgba(255, 255, 255, 0.75);
+  border-radius: 16px;
+  padding: 20px;
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+
+.panel h3 {
+  margin-top: 0;
+  margin-bottom: 12px;
+  color: var(--primary-strong);
+}
+
+.herd-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.herd-button {
+  width: 100%;
+  text-align: left;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: rgba(99, 102, 241, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.herd-button:hover {
+  background: rgba(79, 70, 229, 0.12);
+}
+
+.herd-button.is-active {
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.2), rgba(129, 140, 248, 0.3));
+  border-color: rgba(79, 70, 229, 0.4);
+  box-shadow: 0 12px 25px rgba(99, 102, 241, 0.18);
+}
+
+.herd-name {
+  font-weight: 600;
+  color: var(--primary-strong);
+}
+
+.herd-meta {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+@media (min-width: 900px) {
+  .split-layout {
+    grid-template-columns: 1fr 1.4fr;
+  }
+
+  .page-header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .page-header__text {
+    max-width: 55%;
+  }
+}
+
+@media (max-width: 600px) {
+  .card {
+    padding: 22px;
+  }
+
+  .search-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .pagination {
+    justify-content: center;
+  }
+}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { api } from "./api";
+import "./App.css";
 
 export default function App() {
   const [horses, setHorses] = useState([]);
@@ -113,153 +114,220 @@ export default function App() {
   const stallionOptions = horseOptions;
 
   return (
-    <div style={{ maxWidth: 1100, margin: "20px auto", padding: 16 }}>
-      <h1>Адууны бүртгэлийн апп</h1>
-
-      <form onSubmit={searchAll} style={{ margin: "12px 0", display: "flex", gap: 8 }}>
-        <input
-          value={q}
-          onChange={e=>setQ(e.target.value)}
-          placeholder="Хайх: дугаар, нэр, эзэмшигч, зүс, угшил, тамга, СҮРГИЙН НЭР..."
-          style={{ flex: 1 }}
-        />
-        <button type="submit">Хайх</button>
-      </form>
-
-      <details open style={{ marginBottom: 16 }}>
-        <summary><b>Шинэ адуу нэмэх</b></summary>
-        <form onSubmit={createHorse} style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginTop: 8 }}>
-          <input required placeholder="Адууны дугаар (давтагдашгүй)" value={form.horseId} onChange={e=>setForm(f=>({...f, horseId:e.target.value}))}/>
-          <input placeholder="Нэр" value={form.name} onChange={e=>setForm(f=>({...f, name:e.target.value}))}/>
-          <input placeholder="Төрсөн он" type="number" value={form.birthYear} onChange={e=>setForm(f=>({...f, birthYear:e.target.value}))}/>
-          <input placeholder="Зүс" value={form.color} onChange={e=>setForm(f=>({...f, color:e.target.value}))}/>
-          <input placeholder="Эзэмшигч" value={form.owner} onChange={e=>setForm(f=>({...f, owner:e.target.value}))}/>
-          <input placeholder="Угшил" value={form.lineage} onChange={e=>setForm(f=>({...f, lineage:e.target.value}))}/>
-          <input placeholder="Тамга" value={form.brandMark} onChange={e=>setForm(f=>({...f, brandMark:e.target.value}))}/>
-
-          <select value={form.sire} onChange={e=>setForm(f=>({...f, sire:e.target.value}))}>
-            <option value="">Эцэг (сонгох)</option>
-            {horseOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-          </select>
-          <select value={form.dam} onChange={e=>setForm(f=>({...f, dam:e.target.value}))}>
-            <option value="">Эх (сонгох)</option>
-            {horseOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-          </select>
-
-          <select value={form.herd} onChange={e=>setForm(f=>({...f, herd:e.target.value}))}>
-            <option value="">Сүрэг (сонгох)</option>
-            {herdOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-          </select>
-
-          <div style={{ gridColumn: "1 / -1", display: "flex", gap: 8 }}>
-            <button type="submit">Нэмэх</button>
-            <button type="button" onClick={resetForm}>Цэвэрлэх</button>
+    <div className="app-shell">
+      <div className="app-container">
+        <header className="card page-header">
+          <div className="page-header__text">
+            <h1>Адууны бүртгэлийн апп</h1>
+            <p className="page-subtitle">Адуу бүрийн мэдээллийг эмх цэгцтэй хөтөлж, сүргүүдийн бүрэлдэхүүнийг бодит цагт хянах боломжтой.</p>
           </div>
-        </form>
-      </details>
 
-      <table width="100%" border="1" cellPadding="6" style={{ borderCollapse: "collapse" }}>
-        <thead>
-          <tr>
-            <th>Дугаар</th><th>Нэр</th><th>Төрсөн он</th><th>Зүс</th><th>Эзэмшигч</th>
-            <th>Угшил</th><th>Тамга</th><th>Эцэг</th><th>Эх</th><th>Сүрэг</th><th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {horses.map(h => (
-            <tr key={h._id}>
-              <td>{h.horseId}</td>
-              <td>{h.name}</td>
-              <td>{h.birthYear}</td>
-              <td>{h.color}</td>
-              <td>{h.owner}</td>
-              <td>{h.lineage}</td>
-              <td>{h.brandMark}</td>
-              <td>{h.sire ? (h.sire.horseId + (h.sire.name ? ` (${h.sire.name})` : "")) : "-"}</td>
-              <td>{h.dam ? (h.dam.horseId + (h.dam.name ? ` (${h.dam.name})` : "")) : "-"}</td>
-              <td>{h.herd ? (h.herd.name) : "-"}</td>
-              <td><button onClick={()=>removeHorse(h._id)}>Устгах</button></td>
-            </tr>
-          ))}
-          {horses.length === 0 && <tr><td colSpan="11" style={{ textAlign:"center" }}>Мэдээлэл алга</td></tr>}
-        </tbody>
-      </table>
+          <form onSubmit={searchAll} className="search-form">
+            <input
+              value={q}
+              onChange={e=>setQ(e.target.value)}
+              placeholder="Хайх: дугаар, нэр, эзэмшигч, зүс, угшил, тамга, сүргийн нэр..."
+            />
+            <button type="submit" className="primary-button">Хайх</button>
+          </form>
+        </header>
 
-      <div style={{ marginTop: 10, display: "flex", gap: 8, alignItems: "center" }}>
-        <button disabled={page<=1} onClick={()=>loadHorses(page-1, q)}>Өмнөх</button>
-        <span>{page} / {pages}</span>
-        <button disabled={page>=pages} onClick={()=>loadHorses(page+1, q)}>Дараах</button>
-      </div>
+        <section className="card">
+          <details open className="collapsible">
+            <summary><b>Шинэ адуу нэмэх</b></summary>
+            <p className="section-subtitle">Анкетыг бөглөөд хадгалснаар адуу бүх жагсаалтад болон холбогдох сүргүүдэд автоматаар харагдана.</p>
+            <form onSubmit={createHorse} className="form-grid">
+              <input required placeholder="Адууны дугаар (давтагдашгүй)" value={form.horseId} onChange={e=>setForm(f=>({...f, horseId:e.target.value}))}/>
+              <input placeholder="Нэр" value={form.name} onChange={e=>setForm(f=>({...f, name:e.target.value}))}/>
+              <input placeholder="Төрсөн он" type="number" value={form.birthYear} onChange={e=>setForm(f=>({...f, birthYear:e.target.value}))}/>
+              <input placeholder="Зүс" value={form.color} onChange={e=>setForm(f=>({...f, color:e.target.value}))}/>
+              <input placeholder="Эзэмшигч" value={form.owner} onChange={e=>setForm(f=>({...f, owner:e.target.value}))}/>
+              <input placeholder="Угшил" value={form.lineage} onChange={e=>setForm(f=>({...f, lineage:e.target.value}))}/>
+              <input placeholder="Тамга" value={form.brandMark} onChange={e=>setForm(f=>({...f, brandMark:e.target.value}))}/>
 
-      <hr style={{ margin: "20px 0" }}/>
-      <h2>Сүрэг</h2>
+              <select value={form.sire} onChange={e=>setForm(f=>({...f, sire:e.target.value}))}>
+                <option value="">Эцэг (сонгох)</option>
+                {horseOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+              <select value={form.dam} onChange={e=>setForm(f=>({...f, dam:e.target.value}))}>
+                <option value="">Эх (сонгох)</option>
+                {horseOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
 
-      <details open>
-        <summary><b>Сүрэг үүсгэх</b> (азаргыг сонговол тухайн адуу тэр сүргийн азарга болно)</summary>
-        <form onSubmit={createHerd} style={{ display: "flex", gap: 8, marginTop: 8, flexWrap: "wrap" }}>
-          <input placeholder="Сүргийн нэр" value={herdForm.name} onChange={e=>setHerdForm(f=>({...f, name:e.target.value}))}/>
-          <select value={herdForm.stallion} onChange={e=>setHerdForm(f=>({...f, stallion:e.target.value}))}>
-            <option value="">Азарга (сонгох)</option>
-            {stallionOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-          </select>
-          <button type="submit">Үүсгэх</button>
-        </form>
-      </details>
+              <select value={form.herd} onChange={e=>setForm(f=>({...f, herd:e.target.value}))}>
+                <option value="">Сүрэг (сонгох)</option>
+                {herdOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
 
-      <div style={{ marginTop: 12, display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
-        <div>
-          <b>Сүргүүд</b>
-          <ul style={{ marginTop: 8 }}>
-            {herds.map(h => (
-              <li key={h._id} style={{ cursor: "pointer", padding: "4px 0" }}>
-                <a onClick={() => { setActiveHerd(h._id); setHerdSearch(""); loadHerdHorses(h._id, 1, ""); }}>
-                  {h.name} — гишүүд: {h.membersCount} {h.stallion ? ` | азарга: ${h.stallion.horseId}${h.stallion.name?` (${h.stallion.name})`:""}` : ""}
-                </a>
-              </li>
-            ))}
-            {herds.length === 0 && <i>Сүрэг алга</i>}
-          </ul>
-        </div>
-
-        <div>
-          <b>Сонгосон сүргийн адуунууд</b>
-          {activeHerd ? (
-            <>
-              <form onSubmit={(e)=>{e.preventDefault(); loadHerdHorses(activeHerd, 1, herdSearch);}} style={{ display:"flex", gap:8, margin:"8px 0" }}>
-                <input value={herdSearch} onChange={e=>setHerdSearch(e.target.value)} placeholder="Сүрэг дотор: ямар ч мэдээллээр хайх"/>
-                <button type="submit">Хайх</button>
-              </form>
-
-              <table width="100%" border="1" cellPadding="6" style={{ borderCollapse: "collapse" }}>
-                <thead>
-                  <tr>
-                    <th>Дугаар</th><th>Нэр</th><th>Төрсөн он</th><th>Зүс</th><th>Эзэмшигч</th><th>Эцэг</th><th>Эх</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {herdHorses.map(h => (
-                    <tr key={h._id}>
-                      <td>{h.horseId}</td>
-                      <td>{h.name}</td>
-                      <td>{h.birthYear}</td>
-                      <td>{h.color}</td>
-                      <td>{h.owner}</td>
-                      <td>{h.sire ? (h.sire.horseId + (h.sire.name ? ` (${h.sire.name})` : "")) : "-"}</td>
-                      <td>{h.dam ? (h.dam.horseId + (h.dam.name ? ` (${h.dam.name})` : "")) : "-"}</td>
-                    </tr>
-                  ))}
-                  {herdHorses.length === 0 && <tr><td colSpan="7" style={{ textAlign:"center" }}>Мэдээлэл алга</td></tr>}
-                </tbody>
-              </table>
-
-              <div style={{ marginTop: 10, display: "flex", gap: 8, alignItems: "center" }}>
-                <button disabled={herdPage<=1} onClick={()=>loadHerdHorses(activeHerd, herdPage-1, herdSearch)}>Өмнөх</button>
-                <span>{herdPage} / {herdPages}</span>
-                <button disabled={herdPage>=herdPages} onClick={()=>loadHerdHorses(activeHerd, herdPage+1, herdSearch)}>Дараах</button>
+              <div className="form-actions">
+                <button type="submit" className="primary-button">Нэмэх</button>
+                <button type="button" className="secondary-button" onClick={resetForm}>Цэвэрлэх</button>
               </div>
-            </>
-          ) : <div style={{ marginTop: 8 }}>Зүүн талаас сүрэг сонгоно уу.</div>}
-        </div>
+            </form>
+          </details>
+        </section>
+
+        <section className="card">
+          <div className="section-heading">
+            <div>
+              <h2>Адуунуудын жагсаалт</h2>
+              <p className="section-subtitle">Бүртгэлтэй бүх адууг харах, мэдээллийг засах эсвэл устгах боломжтой.</p>
+            </div>
+          </div>
+
+          <div className="table-wrapper">
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>Дугаар</th>
+                  <th>Нэр</th>
+                  <th>Төрсөн он</th>
+                  <th>Зүс</th>
+                  <th>Эзэмшигч</th>
+                  <th>Угшил</th>
+                  <th>Тамга</th>
+                  <th>Эцэг</th>
+                  <th>Эх</th>
+                  <th>Сүрэг</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {horses.map(h => (
+                  <tr key={h._id}>
+                    <td>{h.horseId}</td>
+                    <td>{h.name}</td>
+                    <td>{h.birthYear}</td>
+                    <td>{h.color}</td>
+                    <td>{h.owner}</td>
+                    <td>{h.lineage}</td>
+                    <td>{h.brandMark}</td>
+                    <td>{h.sire ? (h.sire.horseId + (h.sire.name ? ` (${h.sire.name})` : "")) : "-"}</td>
+                    <td>{h.dam ? (h.dam.horseId + (h.dam.name ? ` (${h.dam.name})` : "")) : "-"}</td>
+                    <td>{h.herd ? (h.herd.name) : "-"}</td>
+                    <td>
+                      <button type="button" className="ghost-button" onClick={()=>removeHorse(h._id)}>Устгах</button>
+                    </td>
+                  </tr>
+                ))}
+                {horses.length === 0 && (
+                  <tr>
+                    <td colSpan="11" className="empty-state">Мэдээлэл алга</td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="pagination">
+            <button disabled={page<=1} onClick={()=>loadHorses(page-1, q)} className="ghost-button">Өмнөх</button>
+            <span>{page} / {pages}</span>
+            <button disabled={page>=pages} onClick={()=>loadHorses(page+1, q)} className="ghost-button">Дараах</button>
+          </div>
+        </section>
+
+        <section className="card">
+          <div className="section-heading">
+            <div>
+              <h2>Сүргийн менежмент</h2>
+              <p className="section-subtitle">Сүргүүдийг үүсгэж, тухайн сүрэгт харьяалагдах адууг нарийвчлан хянана.</p>
+            </div>
+          </div>
+
+          <details open className="collapsible">
+            <summary><b>Сүрэг үүсгэх</b></summary>
+            <p className="section-subtitle">Азаргыг сонговол тухайн адуу тус сүргийн удирдагч азарга болж тэмдэглэгдэнэ.</p>
+            <form onSubmit={createHerd} className="inline-form">
+              <input placeholder="Сүргийн нэр" value={herdForm.name} onChange={e=>setHerdForm(f=>({...f, name:e.target.value}))}/>
+              <select value={herdForm.stallion} onChange={e=>setHerdForm(f=>({...f, stallion:e.target.value}))}>
+                <option value="">Азарга (сонгох)</option>
+                {stallionOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+              <button type="submit" className="primary-button">Үүсгэх</button>
+            </form>
+          </details>
+
+          <div className="split-layout">
+            <div className="panel">
+              <h3>Сүргүүд</h3>
+              <ul className="herd-list">
+                {herds.map(h => (
+                  <li key={h._id}>
+                    <button
+                      type="button"
+                      className={`herd-button${activeHerd === h._id ? " is-active" : ""}`}
+                      onClick={() => { setActiveHerd(h._id); setHerdSearch(""); loadHerdHorses(h._id, 1, ""); }}
+                    >
+                      <span className="herd-name">{h.name}</span>
+                      <span className="herd-meta">Гишүүд: {h.membersCount}</span>
+                      {h.stallion && (
+                        <span className="herd-meta">Азарга: {h.stallion.horseId}{h.stallion.name ? ` (${h.stallion.name})` : ""}</span>
+                      )}
+                    </button>
+                  </li>
+                ))}
+                {herds.length === 0 && <li className="empty-state">Сүрэг алга</li>}
+              </ul>
+            </div>
+
+            <div className="panel">
+              <h3>Сонгосон сүргийн адуунууд</h3>
+              {activeHerd ? (
+                <>
+                  <form
+                    onSubmit={(e)=>{e.preventDefault(); loadHerdHorses(activeHerd, 1, herdSearch);}}
+                    className="search-form search-form--compact"
+                  >
+                    <input value={herdSearch} onChange={e=>setHerdSearch(e.target.value)} placeholder="Сүрэг дотор: ямар ч мэдээллээр хайх"/>
+                    <button type="submit" className="primary-button">Хайх</button>
+                  </form>
+
+                  <div className="table-wrapper">
+                    <table className="data-table">
+                      <thead>
+                        <tr>
+                          <th>Дугаар</th>
+                          <th>Нэр</th>
+                          <th>Төрсөн он</th>
+                          <th>Зүс</th>
+                          <th>Эзэмшигч</th>
+                          <th>Эцэг</th>
+                          <th>Эх</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {herdHorses.map(h => (
+                          <tr key={h._id}>
+                            <td>{h.horseId}</td>
+                            <td>{h.name}</td>
+                            <td>{h.birthYear}</td>
+                            <td>{h.color}</td>
+                            <td>{h.owner}</td>
+                            <td>{h.sire ? (h.sire.horseId + (h.sire.name ? ` (${h.sire.name})` : "")) : "-"}</td>
+                            <td>{h.dam ? (h.dam.horseId + (h.dam.name ? ` (${h.dam.name})` : "")) : "-"}</td>
+                          </tr>
+                        ))}
+                        {herdHorses.length === 0 && (
+                          <tr>
+                            <td colSpan="7" className="empty-state">Мэдээлэл алга</td>
+                          </tr>
+                        )}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  <div className="pagination">
+                    <button disabled={herdPage<=1} onClick={()=>loadHerdHorses(activeHerd, herdPage-1, herdSearch)} className="ghost-button">Өмнөх</button>
+                    <span>{herdPage} / {herdPages}</span>
+                    <button disabled={herdPage>=herdPages} onClick={()=>loadHerdHorses(activeHerd, herdPage+1, herdSearch)} className="ghost-button">Дараах</button>
+                  </div>
+                </>
+              ) : (
+                <div className="empty-state">Зүүн талаас сүрэг сонгоно уу.</div>
+              )}
+            </div>
+          </div>
+        </section>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- refresh the horse registry layout with dedicated sections for search, data entry, listing, and herd management
- introduce reusable styling with a new App.css to deliver a modern glassmorphism-inspired theme and responsive grids
- enhance list and table interactions with clearer pagination controls, active states, and compact search forms

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d14d554c9c832f842af8f8c47df5f4