### PR TITLE
Revamp horse registry UI

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -43,18 +43,36 @@ export default function App() {
   };
 
   const loadHerdHorses = async (herdId, p = 1, query = "") => {
-    if (!herdId) { setHerdHorses([]); setHerdPage(1); setHerdPages(1); return; }
+    if (!herdId) {
+      setHerdHorses([]);
+      setHerdPage(1);
+      setHerdPages(1);
+      return;
+    }
     const { data } = await api.get(`/herds/${herdId}/horses`, { params: { page: p, limit, q: query } });
     setHerdHorses(data.items);
     setHerdPage(data.page);
     setHerdPages(data.pages);
   };
 
-  useEffect(() => { loadHorses(1, ""); loadHerds(""); }, []);
+  useEffect(() => {
+    loadHorses(1, "");
+    loadHerds("");
+  }, []);
 
-  const resetForm = () => setForm({
-    horseId: "", name: "", birthYear: "", color: "", owner: "", lineage: "", brandMark: "", sire: "", dam: "", herd: ""
-  });
+  const resetForm = () =>
+    setForm({
+      horseId: "",
+      name: "",
+      birthYear: "",
+      color: "",
+      owner: "",
+      lineage: "",
+      brandMark: "",
+      sire: "",
+      dam: "",
+      herd: ""
+    });
 
   const createHorse = async (e) => {
     e.preventDefault();
@@ -103,166 +121,409 @@ export default function App() {
   };
 
   const herdOptions = useMemo(
-    () => herds.map(h => ({ value: h._id, label: `${h.name} — (тоо: ${h.membersCount})` })),
+    () => herds.map((h) => ({ value: h._id, label: `${h.name} — (тоо: ${h.membersCount})` })),
     [herds]
   );
   const horseOptions = useMemo(
-    () => horses.map(h => ({ value: h._id, label: `${h.horseId} — ${h.name || ""}`.trim() })),
+    () => horses.map((h) => ({ value: h._id, label: `${h.horseId} — ${h.name || ""}`.trim() })),
     [horses]
   );
   const stallionOptions = horseOptions;
 
   return (
-    <div style={{ maxWidth: 1100, margin: "20px auto", padding: 16 }}>
-      <h1>Адууны бүртгэлийн апп</h1>
-
-      <form onSubmit={searchAll} style={{ margin: "12px 0", display: "flex", gap: 8 }}>
-        <input
-          value={q}
-          onChange={e=>setQ(e.target.value)}
-          placeholder="Хайх: дугаар, нэр, эзэмшигч, зүс, угшил, тамга, СҮРГИЙН НЭР..."
-          style={{ flex: 1 }}
-        />
-        <button type="submit">Хайх</button>
-      </form>
-
-      <details open style={{ marginBottom: 16 }}>
-        <summary><b>Шинэ адуу нэмэх</b></summary>
-        <form onSubmit={createHorse} style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginTop: 8 }}>
-          <input required placeholder="Адууны дугаар (давтагдашгүй)" value={form.horseId} onChange={e=>setForm(f=>({...f, horseId:e.target.value}))}/>
-          <input placeholder="Нэр" value={form.name} onChange={e=>setForm(f=>({...f, name:e.target.value}))}/>
-          <input placeholder="Төрсөн он" type="number" value={form.birthYear} onChange={e=>setForm(f=>({...f, birthYear:e.target.value}))}/>
-          <input placeholder="Зүс" value={form.color} onChange={e=>setForm(f=>({...f, color:e.target.value}))}/>
-          <input placeholder="Эзэмшигч" value={form.owner} onChange={e=>setForm(f=>({...f, owner:e.target.value}))}/>
-          <input placeholder="Угшил" value={form.lineage} onChange={e=>setForm(f=>({...f, lineage:e.target.value}))}/>
-          <input placeholder="Тамга" value={form.brandMark} onChange={e=>setForm(f=>({...f, brandMark:e.target.value}))}/>
-
-          <select value={form.sire} onChange={e=>setForm(f=>({...f, sire:e.target.value}))}>
-            <option value="">Эцэг (сонгох)</option>
-            {horseOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-          </select>
-          <select value={form.dam} onChange={e=>setForm(f=>({...f, dam:e.target.value}))}>
-            <option value="">Эх (сонгох)</option>
-            {horseOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-          </select>
-
-          <select value={form.herd} onChange={e=>setForm(f=>({...f, herd:e.target.value}))}>
-            <option value="">Сүрэг (сонгох)</option>
-            {herdOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-          </select>
-
-          <div style={{ gridColumn: "1 / -1", display: "flex", gap: 8 }}>
-            <button type="submit">Нэмэх</button>
-            <button type="button" onClick={resetForm}>Цэвэрлэх</button>
+    <div className="app-shell">
+      <aside className="sidebar">
+        <div className="sidebar__brand">
+          <div className="brand-icon">Х</div>
+          <div>
+            <div className="brand-title">ХҮННҮ</div>
+            <div className="brand-subtitle">Админ самбар</div>
           </div>
-        </form>
-      </details>
-
-      <div className="table-card">
-        <table className="data-table">
-          <thead>
-            <tr>
-              <th>Дугаар</th><th>Нэр</th><th>Төрсөн он</th><th>Зүс</th><th>Эзэмшигч</th>
-              <th>Угшил</th><th>Тамга</th><th>Эцэг</th><th>Эх</th><th>Сүрэг</th><th></th>
-            </tr>
-          </thead>
-          <tbody>
-            {horses.map(h => (
-              <tr key={h._id}>
-                <td>{h.horseId}</td>
-                <td>{h.name}</td>
-                <td>{h.birthYear}</td>
-                <td>{h.color}</td>
-                <td>{h.owner}</td>
-                <td>{h.lineage}</td>
-                <td>{h.brandMark}</td>
-                <td>{h.sire ? (h.sire.horseId + (h.sire.name ? ` (${h.sire.name})` : "")) : "-"}</td>
-                <td>{h.dam ? (h.dam.horseId + (h.dam.name ? ` (${h.dam.name})` : "")) : "-"}</td>
-                <td>{h.herd ? (h.herd.name) : "-"}</td>
-                <td className="table-actions"><button onClick={()=>removeHorse(h._id)}>Устгах</button></td>
-              </tr>
-            ))}
-            {horses.length === 0 && <tr><td colSpan="11" style={{ textAlign:"center" }}>Мэдээлэл алга</td></tr>}
-          </tbody>
-        </table>
-      </div>
-
-      <div style={{ marginTop: 10, display: "flex", gap: 8, alignItems: "center" }}>
-        <button disabled={page<=1} onClick={()=>loadHorses(page-1, q)}>Өмнөх</button>
-        <span>{page} / {pages}</span>
-        <button disabled={page>=pages} onClick={()=>loadHorses(page+1, q)}>Дараах</button>
-      </div>
-
-      <hr style={{ margin: "20px 0" }}/>
-      <h2>Сүрэг</h2>
-
-      <details open>
-        <summary><b>Сүрэг үүсгэх</b> (азаргыг сонговол тухайн адуу тэр сүргийн азарга болно)</summary>
-        <form onSubmit={createHerd} style={{ display: "flex", gap: 8, marginTop: 8, flexWrap: "wrap" }}>
-          <input placeholder="Сүргийн нэр" value={herdForm.name} onChange={e=>setHerdForm(f=>({...f, name:e.target.value}))}/>
-          <select value={herdForm.stallion} onChange={e=>setHerdForm(f=>({...f, stallion:e.target.value}))}>
-            <option value="">Азарга (сонгох)</option>
-            {stallionOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-          </select>
-          <button type="submit">Үүсгэх</button>
-        </form>
-      </details>
-
-      <div style={{ marginTop: 12, display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
-        <div>
-          <b>Сүргүүд</b>
-          <ul style={{ marginTop: 8 }}>
-            {herds.map(h => (
-              <li key={h._id} style={{ cursor: "pointer", padding: "4px 0" }}>
-                <a onClick={() => { setActiveHerd(h._id); setHerdSearch(""); loadHerdHorses(h._id, 1, ""); }}>
-                  {h.name} — гишүүд: {h.membersCount} {h.stallion ? ` | азарга: ${h.stallion.horseId}${h.stallion.name?` (${h.stallion.name})`:""}` : ""}
-                </a>
-              </li>
-            ))}
-            {herds.length === 0 && <i>Сүрэг алга</i>}
-          </ul>
         </div>
+        <nav className="sidebar__nav">
+          <span className="nav-label">Глобал</span>
+          <button type="button" className="nav-item active">Дашбоард</button>
+          <button type="button" className="nav-item">Давтан сургалт</button>
+          <button type="button" className="nav-item">Тайлан</button>
+          <span className="nav-label">Менежмент</span>
+          <button type="button" className="nav-item">Хэрэглэгчид</button>
+          <button type="button" className="nav-item">Тохиргоо</button>
+        </nav>
+        <div className="sidebar__footer">
+          <button type="button" className="btn btn-light">Гарах</button>
+        </div>
+      </aside>
 
-        <div>
-          <b>Сонгосон сүргийн адуунууд</b>
-          {activeHerd ? (
-            <>
-              <form onSubmit={(e)=>{e.preventDefault(); loadHerdHorses(activeHerd, 1, herdSearch);}} style={{ display:"flex", gap:8, margin:"8px 0" }}>
-                <input value={herdSearch} onChange={e=>setHerdSearch(e.target.value)} placeholder="Сүрэг дотор: ямар ч мэдээллээр хайх"/>
-                <button type="submit">Хайх</button>
-              </form>
+      <div className="content-area">
+        <header className="topbar">
+          <div>
+            <div className="topbar__eyebrow">Сургалтын модуль байршил</div>
+            <h1 className="topbar__title">Бүртгэлийн маягт</h1>
+          </div>
+          <div className="topbar__actions">
+            <button type="button" className="btn btn-light">Тусламж</button>
+            <div className="user-chip">
+              <div className="user-chip__avatar">О</div>
+              <div>
+                <div className="user-chip__name">Оюунаа</div>
+                <div className="user-chip__role">Админ</div>
+              </div>
+            </div>
+          </div>
+        </header>
 
-              <div className="table-card">
-                <table className="data-table">
-                  <thead>
-                    <tr>
-                      <th>Дугаар</th><th>Нэр</th><th>Төрсөн он</th><th>Зүс</th><th>Эзэмшигч</th><th>Эцэг</th><th>Эх</th>
+        <div className="page-wrapper">
+          <section className="page-hero">
+            <div>
+              <div className="hero-eyebrow">Бүртгэлийн модуль</div>
+              <h2>Адууны бүртгэлийн удирдлага</h2>
+              <p>Сүрэг, угшил болон эзэмшигчийн мэдээллийг нэг дор удирдаарай.</p>
+              <div className="hero-actions">
+                <button type="button" className="btn btn-primary">Шинэ маягт</button>
+                <button type="button" className="btn btn-ghost">Хуваалцах</button>
+              </div>
+            </div>
+            <div className="hero-stats">
+              <div className="stat-card">
+                <span className="stat-label">Адуунууд</span>
+                <strong>{horses.length}</strong>
+                <small>энэ хуудсан дахь бүртгэл</small>
+              </div>
+              <div className="stat-card">
+                <span className="stat-label">Сүргүүд</span>
+                <strong>{herds.length}</strong>
+                <small>идэвхтэй бүртгэл</small>
+              </div>
+            </div>
+          </section>
+
+          <section className="card">
+            <header className="card__header">
+              <div>
+                <h3>Ерөнхий хайлт</h3>
+                <p>Адуу, эзэмшигч эсвэл сүргийн нэрээр хайлт хийх боломжтой.</p>
+              </div>
+            </header>
+            <form onSubmit={searchAll} className="search-form">
+              <input
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+                placeholder="Хайх: дугаар, нэр, эзэмшигч, зүс, угшил, тамга, сүргийн нэр..."
+              />
+              <button type="submit" className="btn btn-primary">Хайх</button>
+            </form>
+          </section>
+
+          <section className="card">
+            <header className="card__header">
+              <div>
+                <h3>Шинэ адуу нэмэх</h3>
+                <p>Адууны угшил болон сүргийн мэдээллийг дэлгэрэнгүй бөглөнө үү.</p>
+              </div>
+            </header>
+            <form onSubmit={createHorse} className="form-grid">
+              <input
+                required
+                placeholder="Адууны дугаар (давтагдашгүй)"
+                value={form.horseId}
+                onChange={(e) => setForm((f) => ({ ...f, horseId: e.target.value }))}
+              />
+              <input
+                placeholder="Нэр"
+                value={form.name}
+                onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+              />
+              <input
+                placeholder="Төрсөн он"
+                type="number"
+                value={form.birthYear}
+                onChange={(e) => setForm((f) => ({ ...f, birthYear: e.target.value }))}
+              />
+              <input
+                placeholder="Зүс"
+                value={form.color}
+                onChange={(e) => setForm((f) => ({ ...f, color: e.target.value }))}
+              />
+              <input
+                placeholder="Эзэмшигч"
+                value={form.owner}
+                onChange={(e) => setForm((f) => ({ ...f, owner: e.target.value }))}
+              />
+              <input
+                placeholder="Угшил"
+                value={form.lineage}
+                onChange={(e) => setForm((f) => ({ ...f, lineage: e.target.value }))}
+              />
+              <input
+                placeholder="Тамга"
+                value={form.brandMark}
+                onChange={(e) => setForm((f) => ({ ...f, brandMark: e.target.value }))}
+              />
+
+              <select value={form.sire} onChange={(e) => setForm((f) => ({ ...f, sire: e.target.value }))}>
+                <option value="">Эцэг (сонгох)</option>
+                {horseOptions.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+              <select value={form.dam} onChange={(e) => setForm((f) => ({ ...f, dam: e.target.value }))}>
+                <option value="">Эх (сонгох)</option>
+                {horseOptions.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+
+              <select value={form.herd} onChange={(e) => setForm((f) => ({ ...f, herd: e.target.value }))}>
+                <option value="">Сүрэг (сонгох)</option>
+                {herdOptions.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+
+              <div className="form-actions">
+                <button type="submit" className="btn btn-primary">
+                  Нэмэх
+                </button>
+                <button type="button" className="btn btn-ghost" onClick={resetForm}>
+                  Цэвэрлэх
+                </button>
+              </div>
+            </form>
+          </section>
+
+          <section className="card">
+            <header className="card__header">
+              <div>
+                <h3>Адуунуудын жагсаалт</h3>
+                <p>Хуудас хооронд шилжиж, шаардлагатай үед бүртгэлийг устгана уу.</p>
+              </div>
+            </header>
+            <div className="table-card">
+              <table className="data-table">
+                <thead>
+                  <tr>
+                    <th>Дугаар</th>
+                    <th>Нэр</th>
+                    <th>Төрсөн он</th>
+                    <th>Зүс</th>
+                    <th>Эзэмшигч</th>
+                    <th>Угшил</th>
+                    <th>Тамга</th>
+                    <th>Эцэг</th>
+                    <th>Эх</th>
+                    <th>Сүрэг</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {horses.map((h) => (
+                    <tr key={h._id}>
+                      <td>{h.horseId}</td>
+                      <td>{h.name}</td>
+                      <td>{h.birthYear}</td>
+                      <td>{h.color}</td>
+                      <td>{h.owner}</td>
+                      <td>{h.lineage}</td>
+                      <td>{h.brandMark}</td>
+                      <td>{h.sire ? h.sire.horseId + (h.sire.name ? ` (${h.sire.name})` : "") : "-"}</td>
+                      <td>{h.dam ? h.dam.horseId + (h.dam.name ? ` (${h.dam.name})` : "") : "-"}</td>
+                      <td>{h.herd ? h.herd.name : "-"}</td>
+                      <td className="table-actions">
+                        <button type="button" className="btn btn-danger" onClick={() => removeHorse(h._id)}>
+                          Устгах
+                        </button>
+                      </td>
                     </tr>
-                  </thead>
-                  <tbody>
-                    {herdHorses.map(h => (
-                      <tr key={h._id}>
-                        <td>{h.horseId}</td>
-                        <td>{h.name}</td>
-                        <td>{h.birthYear}</td>
-                        <td>{h.color}</td>
-                        <td>{h.owner}</td>
-                        <td>{h.sire ? (h.sire.horseId + (h.sire.name ? ` (${h.sire.name})` : "")) : "-"}</td>
-                        <td>{h.dam ? (h.dam.horseId + (h.dam.name ? ` (${h.dam.name})` : "")) : "-"}</td>
-                      </tr>
-                    ))}
-                    {herdHorses.length === 0 && <tr><td colSpan="7" style={{ textAlign:"center" }}>Мэдээлэл алга</td></tr>}
-                  </tbody>
-                </table>
+                  ))}
+                  {horses.length === 0 && (
+                    <tr>
+                      <td colSpan="11" style={{ textAlign: "center" }}>
+                        Мэдээлэл алга
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="pagination">
+              <button
+                type="button"
+                className="btn btn-light"
+                disabled={page <= 1}
+                onClick={() => loadHorses(page - 1, q)}
+              >
+                Өмнөх
+              </button>
+              <span className="pagination__status">
+                {page} / {pages}
+              </span>
+              <button
+                type="button"
+                className="btn btn-light"
+                disabled={page >= pages}
+                onClick={() => loadHorses(page + 1, q)}
+              >
+                Дараах
+              </button>
+            </div>
+          </section>
+
+          <section className="card">
+            <header className="card__header">
+              <div>
+                <h3>Сүрэг удирдлага</h3>
+                <p>Сүрэг үүсгэж, гишүүдийн жагсаалтыг удирдаарай.</p>
+              </div>
+            </header>
+            <form onSubmit={createHerd} className="herd-form">
+              <input
+                placeholder="Сүргийн нэр"
+                value={herdForm.name}
+                onChange={(e) => setHerdForm((f) => ({ ...f, name: e.target.value }))}
+              />
+              <select
+                value={herdForm.stallion}
+                onChange={(e) => setHerdForm((f) => ({ ...f, stallion: e.target.value }))}
+              >
+                <option value="">Азарга (сонгох)</option>
+                {stallionOptions.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+              <button type="submit" className="btn btn-primary">
+                Үүсгэх
+              </button>
+            </form>
+
+            <div className="split-panels">
+              <div className="panel">
+                <div className="panel__header">
+                  <h4>Сүргүүд</h4>
+                  <span className="panel__meta">Нийт {herds.length}</span>
+                </div>
+                <ul className="herd-list">
+                  {herds.map((h) => (
+                    <li key={h._id} className={activeHerd === h._id ? "active" : ""}>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setActiveHerd(h._id);
+                          setHerdSearch("");
+                          loadHerdHorses(h._id, 1, "");
+                        }}
+                      >
+                        <span className="herd-name">{h.name}</span>
+                        <span className="herd-meta">Гишүүд: {h.membersCount}</span>
+                        {h.stallion ? (
+                          <span className="herd-meta">
+                            Азарга: {h.stallion.horseId}
+                            {h.stallion.name ? ` (${h.stallion.name})` : ""}
+                          </span>
+                        ) : null}
+                      </button>
+                    </li>
+                  ))}
+                  {herds.length === 0 && <li className="empty">Сүрэг алга</li>}
+                </ul>
               </div>
 
-              <div style={{ marginTop: 10, display: "flex", gap: 8, alignItems: "center" }}>
-                <button disabled={herdPage<=1} onClick={()=>loadHerdHorses(activeHerd, herdPage-1, herdSearch)}>Өмнөх</button>
-                <span>{herdPage} / {herdPages}</span>
-                <button disabled={herdPage>=herdPages} onClick={()=>loadHerdHorses(activeHerd, herdPage+1, herdSearch)}>Дараах</button>
+              <div className="panel">
+                <div className="panel__header">
+                  <h4>Сонгосон сүргийн адуунууд</h4>
+                  {activeHerd && <span className="panel__meta">{herdHorses.length} илэрц</span>}
+                </div>
+                {activeHerd ? (
+                  <>
+                    <form
+                      onSubmit={(e) => {
+                        e.preventDefault();
+                        loadHerdHorses(activeHerd, 1, herdSearch);
+                      }}
+                      className="search-form search-form--compact"
+                    >
+                      <input
+                        value={herdSearch}
+                        onChange={(e) => setHerdSearch(e.target.value)}
+                        placeholder="Сүрэг дотор: ямар ч мэдээллээр хайх"
+                      />
+                      <button type="submit" className="btn btn-primary">
+                        Хайх
+                      </button>
+                    </form>
+
+                    <div className="table-card">
+                      <table className="data-table">
+                        <thead>
+                          <tr>
+                            <th>Дугаар</th>
+                            <th>Нэр</th>
+                            <th>Төрсөн он</th>
+                            <th>Зүс</th>
+                            <th>Эзэмшигч</th>
+                            <th>Эцэг</th>
+                            <th>Эх</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {herdHorses.map((h) => (
+                            <tr key={h._id}>
+                              <td>{h.horseId}</td>
+                              <td>{h.name}</td>
+                              <td>{h.birthYear}</td>
+                              <td>{h.color}</td>
+                              <td>{h.owner}</td>
+                              <td>{h.sire ? h.sire.horseId + (h.sire.name ? ` (${h.sire.name})` : "") : "-"}</td>
+                              <td>{h.dam ? h.dam.horseId + (h.dam.name ? ` (${h.dam.name})` : "") : "-"}</td>
+                            </tr>
+                          ))}
+                          {herdHorses.length === 0 && (
+                            <tr>
+                              <td colSpan="7" style={{ textAlign: "center" }}>
+                                Мэдээлэл алга
+                              </td>
+                            </tr>
+                          )}
+                        </tbody>
+                      </table>
+                    </div>
+
+                    <div className="pagination">
+                      <button
+                        type="button"
+                        className="btn btn-light"
+                        disabled={herdPage <= 1}
+                        onClick={() => loadHerdHorses(activeHerd, herdPage - 1, herdSearch)}
+                      >
+                        Өмнөх
+                      </button>
+                      <span className="pagination__status">
+                        {herdPage} / {herdPages}
+                      </span>
+                      <button
+                        type="button"
+                        className="btn btn-light"
+                        disabled={herdPage >= herdPages}
+                        onClick={() => loadHerdHorses(activeHerd, herdPage + 1, herdSearch)}
+                      >
+                        Дараах
+                      </button>
+                    </div>
+                  </>
+                ) : (
+                  <div className="empty-panel">Зүүн талаас сүрэг сонгоно уу.</div>
+                )}
               </div>
-            </>
-          ) : <div style={{ marginTop: 8 }}>Зүүн талаас сүрэг сонгоно уу.</div>}
+            </div>
+          </section>
         </div>
       </div>
     </div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,43 +1,397 @@
 :root {
   color-scheme: light;
-  font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
   line-height: 1.5;
+  color: #1f2933;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
   background: #f5f7fb;
+}
+
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+  background: #f5f7fb;
+}
+
+.sidebar {
+  width: 240px;
+  background: linear-gradient(180deg, #101c3d 0%, #172755 100%);
+  color: #f8fbff;
+  padding: 24px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.sidebar__brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.brand-icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.16);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 20px;
+}
+
+.brand-title {
+  font-weight: 700;
+  font-size: 18px;
+}
+
+.brand-subtitle {
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+.sidebar__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.nav-label {
+  text-transform: uppercase;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  opacity: 0.6;
+  margin-top: 16px;
+}
+
+.sidebar__nav .nav-label:first-child {
+  margin-top: 0;
+}
+
+.nav-item {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  padding: 10px 12px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.nav-item:hover {
+  background: rgba(255, 255, 255, 0.1);
+  transform: translateX(2px);
+}
+
+.nav-item.active {
+  background: #ffffff;
+  color: #14204b;
+  font-weight: 600;
+}
+
+.sidebar__footer {
+  margin-top: auto;
+}
+
+.content-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.topbar {
+  background: #ffffff;
+  border-bottom: 1px solid #e3e8f4;
+  padding: 20px 32px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.topbar__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 11px;
+  color: #64748b;
+}
+
+.topbar__title {
+  margin: 4px 0 0;
+  font-size: 26px;
+  font-weight: 700;
+  color: #111827;
+}
+
+.topbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.user-chip {
+  background: #f5f7fb;
+  border-radius: 20px;
+  padding: 6px 12px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  box-shadow: inset 0 0 0 1px #d8e1ff;
+}
+
+.user-chip__avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: #4c6fff;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
+.user-chip__name {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.user-chip__role {
+  font-size: 12px;
+  color: #64748b;
+}
+
+.page-wrapper {
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.page-hero {
+  background: linear-gradient(110deg, #e8edff 0%, #ffffff 100%);
+  border-radius: 24px;
+  padding: 32px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+}
+
+.page-hero h2 {
+  margin: 8px 0 12px;
+  font-size: 28px;
+  color: #0f172a;
+}
+
+.hero-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 12px;
+  color: #5b6c9b;
+}
+
+.hero-actions {
+  margin-top: 20px;
+  display: flex;
+  gap: 12px;
+}
+
+.hero-stats {
+  display: flex;
+  gap: 16px;
+}
+
+.stat-card {
+  background: #ffffff;
+  border-radius: 18px;
+  padding: 18px 20px;
+  min-width: 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  box-shadow: 0 12px 24px rgba(148, 163, 184, 0.18);
+}
+
+.stat-label {
+  font-size: 13px;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.stat-card strong {
+  font-size: 28px;
+  color: #101c3d;
+}
+
+.stat-card small {
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 24px 28px;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.04);
+}
+
+.card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+
+.card__header h3 {
+  margin: 0;
+  font-size: 20px;
+  color: #111c4e;
+}
+
+.card__header p {
+  margin: 6px 0 0;
+  font-size: 14px;
+  color: #64748b;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid #d2dcff;
+  background: #f8faff;
+  font: inherit;
   color: #1f2933;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: #4c6fff;
+  box-shadow: 0 0 0 3px rgba(76, 111, 255, 0.15);
+  background: #ffffff;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: 12px;
+  border: none;
+  font-weight: 600;
+  font-size: 14px;
+  padding: 10px 18px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(67, 126, 247, 0.2);
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #437ef7 0%, #3b68f0 100%);
+  color: #ffffff;
+}
+
+.btn-light {
+  background: #eef3ff;
+  color: #274282;
+  box-shadow: inset 0 0 0 1px rgba(67, 126, 247, 0.3);
+}
+
+.btn-ghost {
+  background: rgba(255, 255, 255, 0.6);
+  color: #274282;
+  box-shadow: inset 0 0 0 1px rgba(67, 126, 247, 0.35);
+}
+
+.btn-danger {
+  background: linear-gradient(135deg, #f97066 0%, #f04438 100%);
+  color: #ffffff;
+}
+
+.search-form {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.search-form input {
+  flex: 1 1 240px;
+}
+
+.search-form--compact {
+  margin-top: 12px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.form-actions {
+  display: flex;
+  gap: 12px;
+  grid-column: 1 / -1;
+  justify-content: flex-end;
 }
 
 .table-card {
-  margin-top: 12px;
   border: 1px solid #dce3f0;
-  border-radius: 12px;
+  border-radius: 16px;
   background: #ffffff;
-  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.05);
+  box-shadow: inset 0 0 0 1px #eef2ff;
   overflow-x: auto;
 }
 
 .table-card .data-table {
   width: 100%;
-  min-width: 640px;
+  min-width: 760px;
   border-collapse: collapse;
-  border-radius: 12px;
-  overflow: hidden;
 }
 
 .data-table thead th {
   background: #eef3ff;
   color: #1f2a44;
   font-weight: 600;
+  padding: 14px 16px;
+  text-align: left;
 }
 
 .data-table th,
 .data-table td {
-  padding: 10px 12px;
+  padding: 12px 16px;
   border-bottom: 1px solid #e3e8ef;
-  text-align: left;
   font-size: 14px;
 }
 
@@ -51,9 +405,145 @@ body {
 
 .table-actions {
   white-space: nowrap;
-  text-align: center;
+  text-align: right;
 }
 
-.table-actions button {
-  padding: 6px 10px;
+.pagination {
+  margin-top: 18px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.pagination__status {
+  font-weight: 600;
+  color: #1f2a44;
+}
+
+.herd-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.herd-form input,
+.herd-form select {
+  flex: 1 1 220px;
+}
+
+.split-panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+.panel {
+  border: 1px solid #e3e8f4;
+  border-radius: 18px;
+  padding: 18px;
+  background: #f9fbff;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.panel__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.panel__header h4 {
+  margin: 0;
+  font-size: 16px;
+  color: #1a2658;
+}
+
+.panel__meta {
+  font-size: 12px;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.herd-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.herd-list li button {
+  width: 100%;
+  background: #ffffff;
+  border: none;
+  border-radius: 14px;
+  padding: 12px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  cursor: pointer;
+  font: inherit;
+  color: #1f2933;
+  box-shadow: 0 8px 16px rgba(148, 163, 184, 0.2);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.herd-list li button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 28px rgba(148, 163, 184, 0.26);
+}
+
+.herd-list li.active button {
+  border: 2px solid #4c6fff;
+}
+
+.herd-name {
+  font-weight: 600;
+  color: #111c4e;
+}
+
+.herd-meta {
+  font-size: 12px;
+  color: #64748b;
+}
+
+.herd-list .empty {
+  text-align: center;
+  font-size: 13px;
+  color: #94a3b8;
+}
+
+.empty-panel {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 24px;
+  text-align: center;
+  color: #94a3b8;
+  font-size: 14px;
+}
+
+@media (max-width: 960px) {
+  .sidebar {
+    display: none;
+  }
+
+  .content-area {
+    padding-left: 0;
+  }
+
+  .page-wrapper {
+    padding: 24px;
+  }
+
+  .page-hero {
+    padding: 24px;
+  }
 }


### PR DESCRIPTION
## Summary
- add sidebar layout, hero header, and modernized cards for the horse registry experience
- reorganize forms and tables into reusable sections with enhanced action buttons and panels
- refresh styling with gradients, spacing, and responsive tweaks to mirror the referenced design aesthetic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3600ca270832fbf0c179dcd24715e